### PR TITLE
Spotify api requests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,9 @@
 import './styles/App.css'
 import { Outlet, RouterProvider, createBrowserRouter } from 'react-router-dom';
-import HomePage from './pages/homePage.tsx';
+import { HomePage, homePageDataLoader } from './pages/homePage.tsx';
 import ErrorPage from './pages/errorPage.tsx';
 import LoginPage from './pages/loginPage.tsx';
-import { ProfilePage, ProfileDataLoader } from './pages/profilePage.tsx';
+import { ProfilePage, profileDataLoader } from './pages/profilePage.tsx';
 import Authenticator from './components/authentication/Authenticator.tsx';
 import PrivateRouteLoader from './components/authentication/PrivateRouteLoader.tsx';
 
@@ -28,11 +28,12 @@ const router = createBrowserRouter([
       {
         path: "/home",
         element: <HomePage />,
+        loader: homePageDataLoader,
       },
       {
         path: "/profile",
         element: <ProfilePage />,
-        loader: ProfileDataLoader,
+        loader: profileDataLoader,
       }
     ]
   },
@@ -52,7 +53,7 @@ const router = createBrowserRouter([
 export default function App() {
   return (
     <>
-        <RouterProvider router={router} />
+      <RouterProvider router={router} />
     </>
   )
 }

--- a/frontend/src/pages/homePage.tsx
+++ b/frontend/src/pages/homePage.tsx
@@ -1,9 +1,54 @@
-export default function HomePage() {
+import { extractAccessToken, logout } from "../utils/authUtils";
+import { Link, useLoaderData } from "react-router-dom";
+import { getTopArtists } from "../utils/spotifyUtils";
+import { TopArtists } from "../types/spotifyTypes";
+
+export async function homePageDataLoader() {
+    const accessToken = extractAccessToken();
+    const [topArtistData1, topArtistData2] = await Promise.all([
+        getTopArtists(accessToken, 50, 0),
+        getTopArtists(accessToken, 50, 49)
+    ]);
+
+    // Cannot set offsets over 50, so we need to remove the last item from the first request to avoid duplicates
+    const topArtistData1DuplicateRemoved = topArtistData1.items.slice(0, -1);
+
+    const combinedTopArtistData = {
+        items: [...topArtistData1DuplicateRemoved, ...topArtistData2.items],
+        total: topArtistData1.total + topArtistData2.total
+    };
+
+    return combinedTopArtistData;
+}
+
+
+export function HomePage() {
+    const topArtistData = useLoaderData() as TopArtists;
+
+    const handleLogout = () => {
+        logout();
+    }
+
+    const topArtistList = topArtistData?.items?.map((artist, index) => {
+        return <li key={index}>{artist.name} - {artist.popularity}</li>;
+    }) || <p>No Data</p>;
 
     return (
         <div>
             <h1>Home Page</h1>
             <p>Welcome "User"!</p>
+            <Link to="/profile">
+                <button>Go to Profile</button>
+            </Link>
+            <button onClick={handleLogout}>Logout</button>
+
+            <div>
+                <h2>Top Artists</h2>
+                <ol>
+                    {topArtistList}
+                </ol>
+            </div>
+
         </div>
     );
 }

--- a/frontend/src/pages/profilePage.tsx
+++ b/frontend/src/pages/profilePage.tsx
@@ -3,7 +3,7 @@ import { extractAccessToken } from "../utils/authUtils";
 import { spotifyRequest } from "../utils/spotifyUtils";
 import { UserProfile } from "../types/spotifyTypes";
 
-export async function ProfileDataLoader() {
+export async function profileDataLoader() {
   const accessToken = extractAccessToken();
   const profileData = await spotifyRequest("https://api.spotify.com/v1/me", accessToken);
 

--- a/frontend/src/types/spotifyTypes.ts
+++ b/frontend/src/types/spotifyTypes.ts
@@ -3,8 +3,8 @@ export interface UserProfile {
   display_name: string;
   email: string;
   explicit_content: {
-      filter_enabled: boolean,
-      filter_locked: boolean
+    filter_enabled: boolean,
+    filter_locked: boolean
   },
   external_urls: { spotify: string; };
   followers: { href: string; total: number; };
@@ -12,6 +12,29 @@ export interface UserProfile {
   id: string;
   images: Image[];
   product: string;
+  type: string;
+  uri: string;
+}
+
+export interface TopArtists {
+  items: Artist[];
+  total: number;
+  limit: number;
+  offset: number;
+  previous: string;
+  href: string;
+  next: string;
+}
+
+export interface Artist {
+  external_urls: { spotify: string; };
+  followers: { href: string; total: number; };
+  genres: string[];
+  href: string;
+  id: string;
+  images: Image[];
+  name: string;
+  popularity: number;
   type: string;
   uri: string;
 }

--- a/frontend/src/utils/authUtils.ts
+++ b/frontend/src/utils/authUtils.ts
@@ -7,19 +7,11 @@ export function checkAuth(): boolean {
         accessToken = extractAccessToken();
     }
 
-    if (accessToken) {
-        return true;
+    if (!spAuth || accessToken === "No Access Token") {
+        return false;
     }
 
-    return false;
-}
-
-export function checkExpiredToken(): boolean {
-    const spAuth = localStorage.getItem("spAuth");
-    
-
-    
-    return false;
+    return true;
 }
 
 export function extractAccessToken(): string {
@@ -30,7 +22,7 @@ export function extractAccessToken(): string {
     }
     const regex = /"access_token":"([^"]+)"/;
     const match = input.match(regex);
-    if(match) {
+    if (match) {
         return match[1];
     }
     return "No Access Token";
@@ -44,7 +36,7 @@ export function extractRefreshToken(): string {
     }
     const regex = /"refresh_token":"([^"]+)"/;
     const match = input.match(regex);
-    if(match) {
+    if (match) {
         return match[1];
     }
     return "No Refresh Token";
@@ -55,5 +47,7 @@ export function login() {
 }
 
 export function logout() {
-
+    localStorage.removeItem("spAuth");
+    localStorage.removeItem("codeVerifier");
+    window.location.href = "/login";
 }


### PR DESCRIPTION
- Added basic infrastructure for Spotify API requests
- Implemented data loader to retrieve top 99 spotify artists for the user (offset isn't working properly, 99 is the max currently)
- Added logout functionality
- Added rudimentary automatic refresh. Needs to be tested.